### PR TITLE
Feature: jump to relations

### DIFF
--- a/components/ModelNode.tsx
+++ b/components/ModelNode.tsx
@@ -1,6 +1,11 @@
 import cc from "classcat";
 import React from "react";
-import { Handle, Position } from "react-flow-renderer";
+import {
+  Handle,
+  Position,
+  useReactFlow,
+  useStoreApi,
+} from "react-flow-renderer";
 
 import styles from "./Node.module.scss";
 
@@ -26,65 +31,98 @@ const isSource = ({ isList, relationFromFields, relationType }: ColumnData) =>
   ((relationType === "1-n" || relationType === "m-n") && isList) ||
   (relationType === "1-1" && !!relationFromFields?.length);
 
-const ModelNode = ({ data }: ModelNodeProps) => (
-  <table
-    className="font-sans bg-white border-2 border-separate border-black rounded-lg"
-    style={{ minWidth: 200, maxWidth: 500, borderSpacing: 0 }}
-  >
-    <thead title={data.documentation}>
-      <tr>
-        <th
-          className="p-2 font-extrabold bg-gray-200 border-b-2 border-black rounded-t-md"
-          colSpan={4}
-        >
-          {data.name}
-          {!!data.dbName && (
-            <span className="font-mono font-normal">&nbsp;({data.dbName})</span>
-          )}
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      {data.columns.map((col) => (
-        <tr key={col.name} className={styles.row} title={col.documentation}>
-          <td className="font-mono font-semibold border-t-2 border-r-2 border-gray-300">
-            <div className="relative p-2">
-              {col.name}
-              {isTarget(col) && (
-                <Handle
-                  key={`${data.name}-${col.relationName || col.name}`}
-                  className={cc([styles.handle, styles.left])}
-                  type="target"
-                  id={`${data.name}-${col.relationName || col.name}`}
-                  position={Position.Left}
-                  isConnectable={false}
-                />
-              )}
-            </div>
-          </td>
-          <td className="p-2 font-mono border-t-2 border-r-2 border-gray-300">
-            {col.type}
-          </td>
-          <td className="font-mono border-t-2 border-gray-300">
-            <div className="relative p-2">
-              {col.defaultValue || ""}
-              {isSource(col) && (
-                <Handle
-                  key={`${data.name}-${col.relationName}-${col.name}`}
-                  className={cc([styles.handle, styles.right])}
-                  type="source"
-                  id={`${data.name}-${col.relationName}-${col.name}`}
-                  position={Position.Right}
-                  isConnectable={false}
-                />
-              )}
-            </div>
-          </td>
+const ModelNode = ({ data }: ModelNodeProps) => {
+  const store = useStoreApi();
+  const { setCenter, getZoom } = useReactFlow();
+
+  const focusNode = (nodeId: string) => {
+    const { nodeInternals } = store.getState();
+    const nodes = Array.from(nodeInternals).map(([, node]) => node);
+
+    if (nodes.length > 0) {
+      const node = nodes.find((iterNode) => iterNode.id === nodeId);
+
+      if (!node) return;
+
+      const x = node.position.x + node.width / 2;
+      const y = node.position.y + node.height / 2;
+      const zoom = getZoom();
+
+      setCenter(x, y, { zoom, duration: 1000 });
+    }
+  };
+
+  return (
+    <table
+      className="font-sans bg-white border-2 border-separate border-black rounded-lg"
+      style={{ minWidth: 200, maxWidth: 500, borderSpacing: 0 }}
+    >
+      <thead title={data.documentation}>
+        <tr>
+          <th
+            className="p-2 font-extrabold bg-gray-200 border-b-2 border-black rounded-t-md"
+            colSpan={4}
+          >
+            {data.name}
+            {!!data.dbName && (
+              <span className="font-mono font-normal">
+                &nbsp;({data.dbName})
+              </span>
+            )}
+          </th>
         </tr>
-      ))}
-    </tbody>
-  </table>
-);
+      </thead>
+      <tbody>
+        {data.columns.map((col) => (
+          <tr key={col.name} className={styles.row} title={col.documentation}>
+            <td className="font-mono font-semibold border-t-2 border-r-2 border-gray-300">
+              <div
+                className={`relative p-2 ${
+                  (isTarget(col) || isSource(col)) && "cursor-pointer"
+                }`}
+                onClick={() => {
+                  if (!isTarget(col) && !isSource(col)) return;
+
+                  focusNode(col.type);
+                }}
+              >
+                {col.name}
+                {isTarget(col) && (
+                  <Handle
+                    key={`${data.name}-${col.relationName || col.name}`}
+                    className={cc([styles.handle, styles.left])}
+                    type="target"
+                    id={`${data.name}-${col.relationName || col.name}`}
+                    position={Position.Left}
+                    isConnectable={false}
+                  />
+                )}
+              </div>
+            </td>
+            <td className="p-2 font-mono border-t-2 border-r-2 border-gray-300">
+              {col.displayType}
+            </td>
+            <td className="font-mono border-t-2 border-gray-300">
+              <div className="relative p-2">
+                {col.defaultValue || ""}
+                {isSource(col) && (
+                  <Handle
+                    key={`${data.name}-${col.relationName}-${col.name}`}
+                    className={cc([styles.handle, styles.right])}
+                    type="source"
+                    id={`${data.name}-${col.relationName}-${col.name}`}
+                    position={Position.Right}
+                    isConnectable={false}
+                  />
+                )}
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 export interface ModelNodeProps {
   data: ModelNodeData;
 }

--- a/util/dmmfToElements.ts
+++ b/util/dmmfToElements.ts
@@ -27,6 +27,7 @@ const generateEnumNode = ({
   type: "enum",
   position: { x: 0, y: 0 },
   data: {
+    type: "enum",
     name,
     dbName,
     documentation,
@@ -43,6 +44,7 @@ const generateModelNode = (
   type: "model",
   position: { x: 250, y: 25 },
   data: {
+    type: "model",
     name,
     dbName,
     documentation,
@@ -72,7 +74,8 @@ const generateModelNode = (
           (relationName && relations[relationName]) as Relation | undefined
         )?.type,
         // `isList` and `isRequired` are mutually exclusive as per the spec
-        type: type + (isList ? "[]" : !isRequired ? "?" : ""),
+        displayType: type + (isList ? "[]" : !isRequired ? "?" : ""),
+        type,
         defaultValue: !hasDefaultValue
           ? null
           : typeof def === "object"

--- a/util/types.ts
+++ b/util/types.ts
@@ -8,6 +8,7 @@ export interface SchemaError {
 }
 
 export interface EnumNodeData {
+  type: "enum";
   name: string;
   dbName?: string | null;
   documentation?: string;
@@ -15,12 +16,14 @@ export interface EnumNodeData {
 }
 
 export interface ModelNodeData {
+  type: "model";
   name: string;
   dbName?: string | null;
   documentation?: string;
   columns: Array<{
     name: string;
     type: string;
+    displayType: string;
     kind: string;
     documentation?: string;
     isList: boolean;


### PR DESCRIPTION
In this feature user is able to jump to a relation by clicking the property name.

I've used the `type` to keep track of a node type (for navigation) and the type that's displayed to the user is called now `displayType`.

Navigation uses the `setCenter` function of `useReactFlow`, which allows to move focus between nodes by navigation to their `x` and `y`. The motion is smooth (1s) and zoom is preserved.

Unfortunately I couldn't record the screen behaviour 😅 

