### PR TITLE
Fix Linting + Handle Array Types for DefaultValue

### DIFF
--- a/components/FlowView.tsx
+++ b/components/FlowView.tsx
@@ -72,6 +72,7 @@ const FlowView = ({ dmmf }: FlowViewProps) => {
             id="prismaliser-one"
             markerWidth="12.5"
             markerHeight="12.5"
+            // eslint-disable-next-line react/no-unknown-property
             viewBox="-10 -10 20 20"
             orient="auto-start-reverse"
             refX="0"
@@ -90,6 +91,7 @@ const FlowView = ({ dmmf }: FlowViewProps) => {
             id="prismaliser-many"
             markerWidth="12.5"
             markerHeight="12.5"
+            // eslint-disable-next-line react/no-unknown-property
             viewBox="-10 -10 20 20"
             orient="auto-start-reverse"
             refX="0"

--- a/util/dmmfToElements.ts
+++ b/util/dmmfToElements.ts
@@ -89,16 +89,16 @@ const generateModelNode = (
           // `isList` and `isRequired` are mutually exclusive as per the spec
           displayType: type + (isList ? "[]" : !isRequired ? "?" : ""),
           type,
-          defaultValue: !hasDefaultValue
-            ? null
-            : typeof def === "object"
-            ? // JSON.stringify gives us the quotes to show it's a string.
-              // Not a perfect thing but it works ¯\_(ツ)_/¯
-              // TODO: handle array type?
-              `${def.name}(${def.args
-                .map((x) => JSON.stringify(x))
-                .join(", ")})`
-            : def!.toString(),
+          defaultValue:
+            !hasDefaultValue || def === undefined
+              ? null
+              : typeof def === "object" && "name" in def
+              ? `${def.name}(${def.args
+                  .map((arg) => JSON.stringify(arg))
+                  .join(",")})`
+              : kind === "enum"
+              ? def
+              : JSON.stringify(def),
         })
       ),
     },

--- a/util/dmmfToElements.ts
+++ b/util/dmmfToElements.ts
@@ -97,7 +97,7 @@ const generateModelNode = (
                   .map((arg) => JSON.stringify(arg))
                   .join(",")})`
               : kind === "enum"
-              ? def
+              ? def.toString()
               : JSON.stringify(def),
         })
       ),


### PR DESCRIPTION
#41 unfortunately introduced linting errors leading to build errors which resulted in failed deployments

I have fixed those errors, although somebody might want to have a look at why Eslint is complaining about "viewBox" being a "unknown property" to "Marker", which it clearly shouldn't be. I have told Eslint to ignore both those lines for now.

I also resolved a "TODO" while fixing the linting error. 
DefaultValue should now correctly display array types.

Cheers!