### PR TITLE
Add support for multiple relationships with the same type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "typescript.tsdk": "node_modules\\typescript\\lib",
-  "css.lint.unknownAtRules": "ignore"
+  "css.lint.unknownAtRules": "ignore",
+  "cSpell.words": ["datamodel", "DMMF", "reactflow", "Virtuals"]
 }

--- a/components/ModelNode.tsx
+++ b/components/ModelNode.tsx
@@ -78,6 +78,7 @@ const ModelNode = ({ data }: ModelNodeProps) => {
             const targetHandleId = relationEdgeTargetHandleId(
               data.name,
               col.relationData.name,
+              col.name,
             );
             const sourceHandleId = relationEdgeSourceHandleId(
               data.name,

--- a/util/prismaToFlow.ts
+++ b/util/prismaToFlow.ts
@@ -70,9 +70,11 @@ export const relationEdgeSourceHandleId = (
   column: string,
 ) => `${table}-${relation}-${column}`;
 
-// TODO: might need to include column name for multiple relations of same type??
-export const relationEdgeTargetHandleId = (table: string, relation: string) =>
-  `${table}-${relation}`;
+export const relationEdgeTargetHandleId = (
+  table: string,
+  relation: string,
+  column: string,
+) => `${table}-${relation}-${column}`;
 
 const virtualTableName = (relation: string, table: string) =>
   `${relation}-${table}`;
@@ -231,7 +233,12 @@ const relationsToEdges = (
     };
 
     const source = rel.fields.find((f) => f.side === "source")!;
-    const target = rel.fields.find((f) => f.side === "target")!;
+    let target = rel.fields.find((f) => f.side === "target");
+
+    if (!target && rel.virtual)
+      target = rel.fields.find((f) => f.tableName === rel.virtual?.name);
+
+    if (!target) throw new Error("Invalid target");
 
     result.push({
       ...base,
@@ -242,9 +249,12 @@ const relationsToEdges = (
         rel.name,
         source.name,
       ),
-      targetHandle: relationEdgeTargetHandleId(target.tableName, rel.name),
+      targetHandle: relationEdgeTargetHandleId(
+        target.tableName,
+        rel.name,
+        target.name,
+      ),
     });
-    // }
   }
 
   return result;


### PR DESCRIPTION
Sample schema to test it:
```prisma
generator client {
  provider = "prisma-client-js"
}

datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}

model Foo {
  id   String @id @db.Char(16)
  name String

  Faa     Faa[]
  Bar     Bar[] @relation(name: "FooBar")
  BarFrom Bar[] @relation(name: "FooBarFrom")
  BarTo   Bar[] @relation(name: "FooBarTo")
}

model Bar {
  id        String  @id @db.Char(16)
  fooId     String?
  fooFromId String?
  fooToId   String?

  Foo     Foo? @relation(name: "FooBar", fields: [fooId], references: [id])
  FooFrom Foo? @relation(name: "FooBarFrom", fields: [fooFromId], references: [id])
  FooTo   Foo? @relation(name: "FooBarTo", fields: [fooToId], references: [id])
}

model Faa {
  id    String @id
  fooId String

  Foo Foo @relation(fields: [fooId], references: [id])
}
```